### PR TITLE
Note Mercurial dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ AppBundler Maven Build
 This project simply downloads the latest AppBundler code from https://bitbucket.org/infinitekind/appbundler
 and builds a Maven artifact `com.evolvedbinary.appbundler:appbundler`.
 
-To build you will need a macOS machine and Maven 3.6.0+ installed, you can then run:
+To build you will need a macOS machine with Mercurial 5.0.0+ and Maven 3.6.0+ installed. You can then run:
 ```bash
 $ git clone https://github.com/adamretter/appbundler-maven-build.git
 $ cd appbundler-maven-build


### PR DESCRIPTION
Without `hg` installed, `mvn clean package` errors out with this:

> [ERROR] Failed to execute goal org.apache.maven.plugins:maven-scm-plugin:1.11.2:checkout (default) on project appbundler: Cannot run checkout command : : Exception while executing SCM command. Command could not be executed: /bin/sh -c cd '/Users/joe/workspace/appbundler-maven-build/target' && 'hg' 'clone' 'https://bitbucket.org/infinitekind/appbundler' '/Users/joe/workspace/appbundler-maven-build/target/checkout': Error while executing process. Cannot run program "hg" (in directory "/Users/joe/workspace/appbundler-maven-build/target"): error=2, No such file or directory -> [Help 1]

I'm saying Mercurial 5.0 since that's what homebrew installs. 