### PR TITLE
Build universal native library

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -259,7 +259,10 @@
                                 <clearDefaultOptions>true</clearDefaultOptions>
                                 <options>
                                     <option>-arch</option>
-                                    <option>${nar.arch}</option>
+                                    <!-- option>${nar.arch}</option -->
+                                    <option>x86_64</option>
+                                    <option>-arch</option>
+                                    <option>arm64</option>
                                     <option>-mmacosx-version-min=10.9</option>
                                     <option>-fobjc-exceptions</option>
                                     <option>-std=c99</option>
@@ -269,6 +272,11 @@
                             </c>
                             <linker>
                                 <options>
+                                    <!-- option>${nar.arch}</option -->
+                                    <option>-arch</option>
+                                    <option>x86_64</option>
+                                    <option>-arch</option>
+                                    <option>arm64</option>
                                     <option>-framework</option>
                                     <option>Cocoa</option>
                                     <option>-mmacosx-version-min=10.9</option>


### PR DESCRIPTION
Recent gcc on macOS support universal binary.
It is built when `-arch x86_64 -arch arm64` option to compiler and linker.

Closes https://github.com/evolvedbinary/appbundler-maven-build/issues/55